### PR TITLE
Make privateKeyFile optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
         allowOverwrite: false,
         filePattern: 'index.html',
         port: 22,
+        privateKeyFile: null,
         agent: null,
         passphrase: null,
         distDir: function(context) {
@@ -26,7 +27,7 @@ module.exports = {
         }
       },
 
-      requiredConfig: ['username', 'host', 'port', 'remoteDir', 'privateKeyFile'],
+      requiredConfig: ['username', 'host', 'port', 'remoteDir'],
 
       upload: function(context) {
         var allowOverwrite = this.readConfig('allowOverwrite');

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -131,7 +131,7 @@ module.exports = CoreObject.extend({
       port: options.port || '22',
       agent: options.agent,
       passphrase: options.passphrase,
-      privateKey: fs.readFileSync(untildify(options.privateKeyFile))
+      privateKey: options.privateKeyFile ? fs.readFileSync(untildify(options.privateKeyFile)) : null
     };
 
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
This is necessary in order to use the `agent` option, because SSH2 will
ignore `agent` if a `privateKeyFile` is set as well.
