### PR TITLE
Fix `ember-cli/ext/promise` Deprecation for Ember CLI >=2.12.0

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -1,10 +1,11 @@
 var CoreObject = require('core-object');
-var Promise    = require('ember-cli/lib/ext/promise');
+var RSVP       = require('rsvp');
 var ssh2       = require('ssh2');
 var fs         = require('fs');
 var path       = require('path');
 var untildify  = require('untildify');
-var readFile   = Promise.denodeify(fs.readFile);
+var Promise    = RSVP.Promise;
+var readFile   = RSVP.denodeify(fs.readFile);
 
 var ACTIVE_REVISION_EXT = '.active-revision';
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "rsvp": "^3.5.0",
     "ssh2": "^0.4.12",
     "untildify": "^2.1.0"
   },


### PR DESCRIPTION
This resolves the deprecation warning:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead...
```