### PR TITLE
Call this._super() from init

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -14,6 +14,7 @@ var ACTIVE_REVISION_EXT = '.active-revision';
 
 module.exports = CoreObject.extend({
   init: function(options) {
+    this._super(options);
     var plugin = options.plugin;
 
     this._plugin = plugin;


### PR DESCRIPTION
DEPRECATION: Overriding init without calling this._super is deprecated. Please call this._super(), addon: `undefined`